### PR TITLE
Fix database not able to search tables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ type configStruct struct {
 	PSQL_PORT         string
 	PSQL_DBNAME       string
 	PSQL_TIMEZONE     string
-	PSQL_SEARCH_PATH  string
 	PSQL_TimeoutQuick time.Duration
 	PSQL_TimeoutMid   time.Duration
 	PSQL_TimeoutSlow  time.Duration
@@ -28,7 +27,6 @@ func init() {
 	appConfig.PSQL_PORT = os.Getenv("PSQL_PORT")
 	appConfig.PSQL_DBNAME = os.Getenv("PSQL_DBNAME")
 	appConfig.PSQL_TIMEZONE = os.Getenv("PSQL_TIMEZONE")
-	appConfig.PSQL_SEARCH_PATH = os.Getenv("PSQL_SEARCH_PATH")
 
 	durationQuick, err := strconv.Atoi(os.Getenv("PSQL_TIMEOUT_1"))
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type configStruct struct {
 	PSQL_PORT         string
 	PSQL_DBNAME       string
 	PSQL_TIMEZONE     string
+	PSQL_SEARCH_PATH  string
 	PSQL_TimeoutQuick time.Duration
 	PSQL_TimeoutMid   time.Duration
 	PSQL_TimeoutSlow  time.Duration
@@ -27,6 +28,7 @@ func init() {
 	appConfig.PSQL_PORT = os.Getenv("PSQL_PORT")
 	appConfig.PSQL_DBNAME = os.Getenv("PSQL_DBNAME")
 	appConfig.PSQL_TIMEZONE = os.Getenv("PSQL_TIMEZONE")
+	appConfig.PSQL_SEARCH_PATH = os.Getenv("PSQL_SEARCH_PATH")
 
 	durationQuick, err := strconv.Atoi(os.Getenv("PSQL_TIMEOUT_1"))
 	if err != nil {

--- a/internal/db/psql_connect.go
+++ b/internal/db/psql_connect.go
@@ -3,9 +3,10 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"time"
+
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"time"
 
 	"github.com/phincon-backend/laza/config"
 	"github.com/phincon-backend/laza/domain/db"
@@ -39,9 +40,10 @@ func (d *PsqlDB) OpenConnection() {
 	port := appConfig.PSQL_PORT
 	dbname := appConfig.PSQL_DBNAME
 	timezone := appConfig.PSQL_TIMEZONE
+	searchPath := appConfig.PSQL_SEARCH_PATH
 
-	connString := "host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=%s"
-	db_, err := sql.Open("postgres", fmt.Sprintf(connString, host, user, pass, dbname, port, timezone))
+	connString := "host=%s user=%s password=%s dbname=%s port=%s sslmode=disable TimeZone=%s search_path=%s"
+	db_, err := sql.Open("postgres", fmt.Sprintf(connString, host, user, pass, dbname, port, timezone, searchPath))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
By default, PostgreSQL looks at the `public` schema. Adding `search_path` in the DSN fixes this issue. We put tables outside the `public` schema, so they can't find the table requested.

The solution was found in this [Stackoverflow link](https://stackoverflow.com/a/51482726)